### PR TITLE
Reduce RAM usage

### DIFF
--- a/include/MFButton.h
+++ b/include/MFButton.h
@@ -43,7 +43,6 @@ public:
     
 private:
     bool          _state;
-    uint32_t      _last;
     buttonEvent   _handlerList[2];    
 };
 #endif 

--- a/src/MF_Modules/MFButton.cpp
+++ b/src/MF_Modules/MFButton.cpp
@@ -9,17 +9,13 @@ MFButton::MFButton(uint8_t pin, const char * name)
   _pin  = pin;
   _name = name;
   _state = 1;
-  _last = millis();
   pinMode(_pin, INPUT);     // set pin to input
   digitalWrite(_pin, HIGH); // turn on pullup resistors
 }
 
 void MFButton::update()
 {
-    uint32_t now = millis();
-    if (now-_last <= 10) return;
     uint8_t newState = (uint8_t) digitalRead(_pin);
-    _last = now;
     if (newState!=_state) {     
       _state = newState;
       trigger();      

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -1069,8 +1069,12 @@ void OnSetLcdDisplayI2C()
 }
 #endif
 
+uint32_t _lastButtonRead;
 void readButtons()
 {
+  uint32_t now = millis();
+  if (now-_lastButtonRead <= 10) return;
+  _lastButtonRead = now;
   for (int i = 0; i != buttonsRegistered; i++)
   {
     buttons[i].update();


### PR DESCRIPTION
All Buttons are read in a for loop. Every button stores it's own time when it is read the last time, but for all buttons this is the same time (for loop). To save some RAM usage (60bytes for the proMicro) the "debouncing" can be done in the central function (readButtons() ).
Same could be applied to the encoder function, but is not part of the existing pull request. It will "only" save 12Bytes for the proMicro (4 Encoder * 4Byte(_lastmillis in MFENcoder.h) - 4Byte(mobiflight.cpp))...