### PR TITLE
protect Config

### DIFF
--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -776,9 +776,9 @@ void _activateConfig()
   cmdMessenger.sendCmd(kConfigActivated, F("OK"));
 }
 
+char readBuffer[MEM_LEN_CONFIG + 1] = "";
 void readConfig(String cfg)
 {
-  char readBuffer[MEM_LEN_CONFIG + 1] = "";
   char *p = NULL;
   cfg.toCharArray(readBuffer, MEM_LEN_CONFIG);
 


### PR DESCRIPTION
Small change but a longer explanation:

Within readConfig() readBuffer[MEM_LEN_CONFIG + 1] is defined and a RAM area is reserved. Then the config (String cfg) is copied to readBuffer[].
In the nexr steps readBuffer[] is processed, all "." and ":" are exchanged to NULL (string termination) and for each device pointers are defined which are pointing to this reserved RAM area.
At the end of the function readBuffer[] this RAM area is released, but the pointer are sstill pointing to this RAM area.
In the following program it can happen, that additional RAM is required and that the remaining RAM area is not sufficient. In this case the released RAM area from readConfig[] is used and the config is mixed up.

Defining readBuffer[MEM_LEN_CONFIG + 1] globally will avoid that this RAM area will be used again.

I have an other idea not to double the config but still to use the original buffer. This would save additional 256 Bytes of RAM. Most is working but I need some more time to finish this. But for now I would stay with this change.