### PR TITLE
Fix the verison number during build time

### DIFF
--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -46,7 +46,8 @@ char foo;
 
 // The build version comes from an environment variable
 #define STRINGIZER(arg) #arg
-#define VERSION STRINGIZER(BUILD_VERSION)
+#define STR_VALUE(arg) STRINGIZER(arg)
+#define VERSION STR_VALUE(BUILD_VERSION)
 
 //#define DEBUG 1
 


### PR DESCRIPTION
Add a missing macro to convert the environment variable from command line build flags into an actual #define in code.