### PR TITLE
Elral/issue36_2

### DIFF
--- a/include/mobiflight.h
+++ b/include/mobiflight.h
@@ -93,7 +93,7 @@ void OnResetConfig();
 void OnSaveConfig();
 void OnActivateConfig();
 void _activateConfig();
-void readConfig(char * buffer);
+void readConfig();
 void OnUnknownCommand();
 void OnGetInfo();
 void OnGetConfig();

--- a/include/mobiflight.h
+++ b/include/mobiflight.h
@@ -93,7 +93,7 @@ void OnResetConfig();
 void OnSaveConfig();
 void OnActivateConfig();
 void _activateConfig();
-void readConfig(String cfg);
+void readConfig(char * buffer);
 void OnUnknownCommand();
 void OnGetInfo();
 void OnGetConfig();

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -782,17 +782,16 @@ void _activateConfig()
   cmdMessenger.sendCmd(kConfigActivated, F("OK"));
 }
 
-void readConfig(String cfg)
+void readConfig(char * buffer)
 {
-  char readBuffer[MEM_LEN_CONFIG + 1] = "";
+  if (configLength == 0) return;          // command = strtok_r(readBuffer....) not working for Teensy if config is empty!???
   char *p = NULL;
-  cfg.toCharArray(readBuffer, MEM_LEN_CONFIG);
 
-  char *command = strtok_r(readBuffer, ".", &p);
-  char *params[6];
+  char *command = strtok_r(buffer, ".", &p);
   if (*command == 0)
     return;
-
+  char *params[6];
+  
   do
   {
     switch (atoi(command))

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -227,6 +227,7 @@ void OnResetBoard()
   clearRegisteredPins();
   lastCommand = millis();
   loadConfig();
+  OnActivateConfig();             // to be added, was in loadconfig()
   _restoreName();
 }
 
@@ -264,8 +265,9 @@ void loadConfig()
       continue;
     break;
   }
-  readConfig(configBuffer);
-  _activateConfig();
+//  readConfig(configBuffer);   // to be deleted, will be called separatly
+//  _activateConfig();          // to be deleted, will be called separatly
+//  otherwise onGetConfig() will not work
 }
 
 void _storeConfig()
@@ -932,10 +934,12 @@ void OnGetInfo()
 
 void OnGetConfig()
 {
+  loadConfig();
   lastCommand = millis();
   cmdMessenger.sendCmdStart(kInfo);
   cmdMessenger.sendCmdArg(configBuffer);
   cmdMessenger.sendCmdEnd();
+  OnActivateConfig();             // to be added, was in loadconfig()
 }
 
 // Callback function that sets led on or off

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -934,7 +934,7 @@ void OnGetInfo()
 
 void OnGetConfig()
 {
-  loadConfig();
+  loadConfig();                   // to be added
   lastCommand = millis();
   cmdMessenger.sendCmdStart(kInfo);
   cmdMessenger.sendCmdArg(configBuffer);

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -220,9 +220,7 @@ void OnResetBoard()
 {
   EEPROM.setMaxAllowedWrites(1000);
   EEPROM.setMemPool(0, EEPROM_SIZE);
-
   configBuffer[0] = '\0';
-  //readBuffer[0]='\0';
   generateSerial(false);
   clearRegisteredPins();
   lastCommand = millis();
@@ -771,7 +769,7 @@ void OnSaveConfig()
 
 void OnActivateConfig()
 {
-  readConfig(configBuffer);
+  readConfig();
   _activateConfig();
   //cmdMessenger.sendCmd(kConfigActivated, F("OK"));
 }
@@ -782,12 +780,12 @@ void _activateConfig()
   cmdMessenger.sendCmd(kConfigActivated, F("OK"));
 }
 
-void readConfig(char * buffer)
+void readConfig()
 {
-  if (configLength == 0) return;          // command = strtok_r(readBuffer....) not working for Teensy if config is empty!???
+  if (configLength == 0) return;
   char *p = NULL;
 
-  char *command = strtok_r(buffer, ".", &p);
+  char *command = strtok_r(configBuffer, ".", &p);
   if (*command == 0)
     return;
   char *params[6];


### PR DESCRIPTION
This is an alternative pull request to #36.
In this case the config will be loaded again from the EEPROM into the already processed configBuffer (all "," and ";" are replaced by NULL), then it is transfered using already existing CMDMessenger function and at least the configBuffer will be processed again. Smaller changes in onResetBoard() and loadConfig() are required. They original functions are uncomment with additional comments. Advantage is that no changes in CMDMessenger is required, disadvantage is that a connected LCD will be switched ON / OFF every time the connector connects or requests the config.

As also changes in the CMDMessenger for wrapping the #defines are required, I would prefer to add the required function as described in the pull request #36 and to merge not this one.

This pull request will superseed pull request #13.